### PR TITLE
feat: simulate response time

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 
 <div align="center"><img src="https://github.com/antoinechalifour/memento/blob/master/cover.png?raw=true" alt="Memento screenshot"></div>
 
-
 ## Why should one use Memento?
 
 When building a UI or working on any project that rely on external services, some things can slow us down:
@@ -20,7 +19,7 @@ When building a UI or working on any project that rely on external services, som
 
 Memento acts as a development buddy that remembers the requests that your application is sending, the server response, and will respond to your app without the need for requests to go over the internet.
 
-*Pro-tip: Memento may also be used for [stubbing external services for integration or end-to-end testing](./examples/stub-external-services) 🎉*
+_Pro-tip: Memento may also be used for [stubbing external services for integration or end-to-end testing](./examples/stub-external-services) 🎉_
 
 ## Getting started
 
@@ -28,7 +27,7 @@ Memento acts as a development buddy that remembers the requests that your applic
 
 To add Memento to your project, you need to add a `.mementorc` file to your project root.
 
-*Note: you may use any other configuration file supported by [cosmiconfig](https://github.com/davidtheclark/cosmiconfig).*
+_Note: you may use any other configuration file supported by [cosmiconfig](https://github.com/davidtheclark/cosmiconfig)._
 
 The most basic configuration file to cache the [PunkApi](https://punkapi.com/documentation/v2) would look something like this:
 
@@ -42,23 +41,24 @@ The most basic configuration file to cache the [PunkApi](https://punkapi.com/doc
 
 You will then need to configure your app to target `http://localhost:3344` as the API url.
 
-*Note: this should only be done at development time, do not target localhost for your production build!*
+_Note: this should only be done at development time, do not target localhost for your production build!_
 
 **3. Run Memento**
 
-You can then run Memento using `npx @antoinechalifour/memento`. 
+You can then run Memento using `npx @antoinechalifour/memento`.
 
-*Note: `npx` is a command that comes with `npm` when installing Node and enables users to run binaries without installing them manually.*
+_Note: `npx` is a command that comes with `npm` when installing Node and enables users to run binaries without installing them manually._
 
 ## Options
 
 The following options are supported:
 
-| Option         | Description                                    | Example               | Default value  |
-| -------------- | ---------------------------------------------- | --------------------- | -------------- |
-| targetUrl      | The API base URL                               | http://localhost:4000 | None           |
-| port           | The port used to launch Memento                | 9876                  | 3344           |
-| cacheDirectory | The cache directory used for storing responses | memento-integration   | .memento-cache |
+| Option              | Description                                                   | Example               | Default value  |
+| ------------------- | ------------------------------------------------------------- | --------------------- | -------------- |
+| targetUrl           | The API base URL                                              | http://localhost:4000 | None           |
+| port                | The port used to launch Memento                               | 9876                  | 3344           |
+| cacheDirectory      | The cache directory used for storing responses                | memento-integration   | .memento-cache |
+| useRealResponseTime | Whether Memento should respond using the actual response time | true                  | false          |
 
 ## Examples
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -157,6 +157,10 @@ export function createCli({ container }: CreateCliOptions) {
       this.log(
         table([
           [
+            chalk.yellow('Response Time'),
+            chalk.white(response.responseTimeInMs.toString()),
+          ],
+          [
             chalk.yellow('Status code'),
             chalk.white(response.status.toString()),
           ],

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -14,6 +14,10 @@ function getCacheDirectory(directory: string | undefined): string {
   return directory ? path.resolve(directory) : defaultCacheDirectory;
 }
 
+function getUseRealResponseTime(useRealResponseTime: string | undefined) {
+  return useRealResponseTime ? Boolean(useRealResponseTime) : false;
+}
+
 const configExplorer = cosmiconfig('memento');
 const cosmicConfiguration = configExplorer.searchSync();
 
@@ -27,6 +31,9 @@ export const configuration = {
   targetUrl: cosmicConfiguration.config.targetUrl,
   port: getPortFromString(cosmicConfiguration.config.port),
   cacheDirectory: getCacheDirectory(cosmicConfiguration.config.cacheDirectory),
+  useRealResponseTime: getUseRealResponseTime(
+    cosmicConfiguration.config.useRealResponseTime
+  ),
 };
 
 assert(configuration.targetUrl, 'targetUrl option is required');

--- a/src/domain/entity/Response.test.ts
+++ b/src/domain/entity/Response.test.ts
@@ -61,7 +61,8 @@ describe('headers', () => {
         SOURCEMAP: 'sourcemap',
         UPGRADE: 'upgrade',
       },
-      'OK'
+      'OK',
+      0
     );
 
     // When

--- a/src/domain/entity/Response.ts
+++ b/src/domain/entity/Response.ts
@@ -4,7 +4,8 @@ export class Response {
   public constructor(
     public readonly status: number,
     public readonly headers: Headers,
-    public readonly body: string
+    public readonly body: string,
+    public readonly responseTimeInMs: number
   ) {
     this.headers = this.buildHeaders(headers);
   }

--- a/src/domain/usecase/GetRequestDetails.test.ts
+++ b/src/domain/usecase/GetRequestDetails.test.ts
@@ -16,7 +16,7 @@ it('should return a tuple with the request and the response', async () => {
   // Given
   const requestId = 'request-id';
   const request = new Request('GET', '/test', {}, '');
-  const response = new Response(201, {}, 'Hello world');
+  const response = new Response(201, {}, 'Hello world', 66);
 
   (requestRepository.getRequestById as jest.Mock).mockResolvedValue(request);
   (requestRepository.getResponseByRequestId as jest.Mock).mockResolvedValue(

--- a/src/domain/usecase/RefreshRequest.test.ts
+++ b/src/domain/usecase/RefreshRequest.test.ts
@@ -24,7 +24,7 @@ beforeEach(() => {
 
   networkService = getTestNetworkService();
   (networkService.executeRequest as jest.Mock).mockResolvedValue(
-    new Response(200, { 'content-type': 'application/json' }, 'OK')
+    new Response(200, { 'content-type': 'application/json' }, 'OK', 66)
   );
 
   useCase = new RefreshRequest({ requestRepository, networkService });
@@ -48,7 +48,7 @@ it('should clear the request and refetch it', async () => {
       { authorization: 'Bearer token' },
       ''
     ),
-    new Response(200, { 'content-type': 'application/json' }, 'OK')
+    new Response(200, { 'content-type': 'application/json' }, 'OK', 66)
   );
 });
 

--- a/src/domain/usecase/RespondToRequest.test.ts
+++ b/src/domain/usecase/RespondToRequest.test.ts
@@ -1,17 +1,20 @@
-import { RequestRepository } from '../repository';
-import { NetworkService } from '../service';
-
 import {
   getTestRequestRepository,
   getTestNetworkService,
 } from '../../test-utils/infrastructure';
+import { RequestRepository } from '../repository';
+import { NetworkService } from '../service';
 import { Response, Request } from '../entity';
+import { wait } from '../../utils/timers';
 import { RespondToRequest } from './RespondToRequest';
+
+jest.mock('../../utils/timers');
 
 let requestRepository: RequestRepository;
 let networkService: NetworkService;
 
 beforeEach(() => {
+  (wait as jest.Mock).mockReset();
   requestRepository = getTestRequestRepository();
   networkService = getTestNetworkService();
 });
@@ -19,8 +22,27 @@ beforeEach(() => {
 describe('when the response is in the cache', () => {
   beforeEach(() => {
     (requestRepository.getResponseByRequestId as jest.Mock).mockResolvedValue(
-      new Response(200, { 'cache-control': 'something' }, 'some body')
+      new Response(200, { 'cache-control': 'something' }, 'some body', 66)
     );
+  });
+
+  it('should not simulate the response time when useRealResponseTime is set to false', async () => {
+    // Given
+    const useCase = new RespondToRequest({
+      requestRepository,
+      networkService,
+      useRealResponseTime: false,
+    });
+    const method = 'GET';
+    const url = '/beers/1';
+    const headers = { authorization: 'Bearer token' };
+    const body = 'beer information';
+
+    // When
+    await useCase.execute(method, url, headers, body);
+
+    //Then
+    expect(wait).not.toHaveBeenCalled();
   });
 
   it('should return the response from the cache, without using the network', async () => {
@@ -28,6 +50,7 @@ describe('when the response is in the cache', () => {
     const useCase = new RespondToRequest({
       requestRepository,
       networkService,
+      useRealResponseTime: true,
     });
     const method = 'GET';
     const url = '/beers/1';
@@ -39,13 +62,16 @@ describe('when the response is in the cache', () => {
 
     //Then
     expect(response).toEqual(
-      new Response(200, { 'cache-control': 'something' }, 'some body')
+      new Response(200, { 'cache-control': 'something' }, 'some body', 66)
     );
 
     expect(requestRepository.getResponseByRequestId).toHaveBeenCalledTimes(1);
     expect(requestRepository.getResponseByRequestId).toHaveBeenCalledWith(
       new Request(method, url, headers, body).id
     );
+
+    expect(wait).toHaveBeenCalledTimes(1);
+    expect(wait).toHaveBeenCalledWith(66);
 
     expect(networkService.executeRequest).not.toHaveBeenCalled();
   });
@@ -57,7 +83,7 @@ describe('when no response is in the cache', () => {
       null
     );
     (networkService.executeRequest as jest.Mock).mockResolvedValue(
-      new Response(200, { 'cache-control': 'something' }, 'some body')
+      new Response(200, { 'cache-control': 'something' }, 'some body', 66)
     );
   });
 
@@ -65,6 +91,7 @@ describe('when no response is in the cache', () => {
     const useCase = new RespondToRequest({
       requestRepository,
       networkService,
+      useRealResponseTime: true,
     });
     const method = 'GET';
     const url = '/beers/1';
@@ -76,7 +103,7 @@ describe('when no response is in the cache', () => {
 
     //Then
     expect(response).toEqual(
-      new Response(200, { 'cache-control': 'something' }, 'some body')
+      new Response(200, { 'cache-control': 'something' }, 'some body', 66)
     );
 
     expect(networkService.executeRequest).toHaveBeenCalledTimes(1);
@@ -84,12 +111,15 @@ describe('when no response is in the cache', () => {
       new Request(method, url, headers, body)
     );
 
+    expect(wait).toHaveBeenCalledTimes(1);
+    expect(wait).toHaveBeenCalledWith(66);
+
     expect(requestRepository.persistResponseForRequest).toHaveBeenCalledTimes(
       1
     );
     expect(requestRepository.persistResponseForRequest).toHaveBeenCalledWith(
       new Request(method, url, headers, body),
-      new Response(200, { 'cache-control': 'something' }, 'some body')
+      new Response(200, { 'cache-control': 'something' }, 'some body', 66)
     );
   });
 });

--- a/src/domain/usecase/RespondToRequest.ts
+++ b/src/domain/usecase/RespondToRequest.ts
@@ -1,3 +1,4 @@
+import { wait } from '../../utils/timers';
 import { Method, Response, Request } from '../entity';
 import { RequestRepository } from '../repository';
 import { NetworkService } from '../service';
@@ -5,6 +6,7 @@ import { NetworkService } from '../service';
 interface Dependencies {
   requestRepository: RequestRepository;
   networkService: NetworkService;
+  useRealResponseTime: boolean;
 }
 
 export interface Headers {
@@ -14,10 +16,16 @@ export interface Headers {
 export class RespondToRequest {
   private requestRepository: RequestRepository;
   private networkService: NetworkService;
+  private useRealResponseTime: boolean;
 
-  public constructor({ requestRepository, networkService }: Dependencies) {
+  public constructor({
+    requestRepository,
+    networkService,
+    useRealResponseTime,
+  }: Dependencies) {
     this.requestRepository = requestRepository;
     this.networkService = networkService;
+    this.useRealResponseTime = useRealResponseTime;
   }
 
   public async execute(
@@ -39,6 +47,10 @@ export class RespondToRequest {
       response = await this.networkService.executeRequest(request);
 
       await this.requestRepository.persistResponseForRequest(request, response);
+    }
+
+    if (this.useRealResponseTime) {
+      await wait(response.responseTimeInMs);
     }
 
     return response;

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ container.register({
   targetUrl: asValue(configuration.targetUrl),
   cacheDirectory: asValue(configuration.cacheDirectory),
   appVersion: asValue(version),
+  useRealResponseTime: asValue(configuration.useRealResponseTime),
 
   // Use cases
   respondToRequestUseCase: asClass(RespondToRequest),

--- a/src/infrastructure/repository/RequestRepositoryFile.test.ts
+++ b/src/infrastructure/repository/RequestRepositoryFile.test.ts
@@ -48,7 +48,8 @@ describe('persistResponseForRequest', () => {
           {
             'content-type': contentType,
           },
-          JSON.stringify({ id: 'user-1', name: 'John Doe' })
+          JSON.stringify({ id: 'user-1', name: 'John Doe' }),
+          55
         );
 
         // When
@@ -76,6 +77,7 @@ describe('persistResponseForRequest', () => {
           responseHeaders: {
             'content-type': contentType,
           },
+          responseTime: 55,
         });
         expect(bodyContent).toEqual({
           id: 'user-1',
@@ -103,7 +105,8 @@ describe('persistResponseForRequest', () => {
           {
             'content-type': contentType,
           },
-          '<Note><Author>Jane</Author><Content>Hello world</Content></Note>'
+          '<Note><Author>Jane</Author><Content>Hello world</Content></Note>',
+          55
         );
 
         // When
@@ -130,6 +133,7 @@ describe('persistResponseForRequest', () => {
           responseHeaders: {
             'content-type': contentType,
           },
+          responseTime: 55,
         });
         expect(bodyContent).toEqual(
           '<Note><Author>Jane</Author><Content>Hello world</Content></Note>'
@@ -147,7 +151,8 @@ describe('persistResponseForRequest', () => {
       {
         'content-type': 'text/plain',
       },
-      'Hello world'
+      'Hello world',
+      66
     );
 
     // When
@@ -174,6 +179,7 @@ describe('persistResponseForRequest', () => {
       responseHeaders: {
         'content-type': 'text/plain',
       },
+      responseTime: 66,
     });
     expect(bodyContent).toEqual('Hello world');
   });
@@ -182,7 +188,7 @@ describe('persistResponseForRequest', () => {
     // Given
     const requestRepository = getRequestRepository();
     const inputRequest = new Request('GET', '/text', {}, '');
-    const inputResponse = new Response(200, {}, 'Hello world');
+    const inputResponse = new Response(200, {}, 'Hello world', 77);
 
     // When
     await requestRepository.persistResponseForRequest(
@@ -206,6 +212,7 @@ describe('persistResponseForRequest', () => {
       requestBody: '',
       requestHeaders: {},
       responseHeaders: {},
+      responseTime: 77,
     });
     expect(bodyContent).toEqual('Hello world');
   });
@@ -219,7 +226,7 @@ describe('persistResponseForRequest', () => {
       {},
       ''
     );
-    const inputResponse = new Response(200, {}, 'Hello world');
+    const inputResponse = new Response(200, {}, 'Hello world', 77);
 
     // When
     await requestRepository.persistResponseForRequest(
@@ -244,18 +251,19 @@ describe('persistResponseForRequest', () => {
       requestBody: '',
       requestHeaders: {},
       responseHeaders: {},
+      responseTime: 77,
     });
     expect(bodyContent).toEqual('Hello world');
   });
 });
 
 describe('getResponseByRequestId', () => {
-  let requestRepositorysitory: RequestRepository;
+  let requestRepository: RequestRepository;
 
   beforeEach(async () => {
-    requestRepositorysitory = getRequestRepository();
+    requestRepository = getRequestRepository();
 
-    await requestRepositorysitory.persistResponseForRequest(
+    await requestRepository.persistResponseForRequest(
       new Request(
         'GET',
         '/pokemon/pikachu',
@@ -269,14 +277,15 @@ describe('getResponseByRequestId', () => {
         {
           'content-type': 'application/json',
         },
-        JSON.stringify({ id: 'user-1', name: 'John Doe' })
+        JSON.stringify({ id: 'user-1', name: 'John Doe' }),
+        88
       )
     );
   });
 
   it('should deserialize the response', async () => {
     // When
-    const cachedResponse = await requestRepositorysitory.getResponseByRequestId(
+    const cachedResponse = await requestRepository.getResponseByRequestId(
       new Request(
         'GET',
         '/pokemon/pikachu',
@@ -294,7 +303,8 @@ describe('getResponseByRequestId', () => {
         {
           'content-type': 'application/json',
         },
-        JSON.stringify({ id: 'user-1', name: 'John Doe' })
+        JSON.stringify({ id: 'user-1', name: 'John Doe' }),
+        88
       )
     );
   });
@@ -304,9 +314,7 @@ describe('getResponseByRequestId', () => {
     const requestId = 'does-not-exist';
 
     // When
-    const response = await requestRepositorysitory.getResponseByRequestId(
-      requestId
-    );
+    const response = await requestRepository.getResponseByRequestId(requestId);
 
     //Then
     expect(response).toBeNull();
@@ -338,7 +346,8 @@ describe('getAllRequests', () => {
       JSON.stringify({
         id: 'pokemon-1',
         name: 'Bulbasaur',
-      })
+      }),
+      99
     );
     const request2 = new Request(
       'get',
@@ -357,7 +366,8 @@ describe('getAllRequests', () => {
       JSON.stringify({
         id: 'pokemon-151',
         name: 'Mew',
-      })
+      }),
+      100
     );
 
     await Promise.all([
@@ -419,7 +429,8 @@ describe('getRequestById', () => {
       JSON.stringify({
         id: 'pokemon-1',
         name: 'Bulbasaur',
-      })
+      }),
+      110
     );
     const request2 = new Request(
       'get',
@@ -438,7 +449,8 @@ describe('getRequestById', () => {
       JSON.stringify({
         id: 'pokemon-151',
         name: 'Mew',
-      })
+      }),
+      120
     );
 
     await Promise.all([
@@ -506,7 +518,8 @@ describe('deleteAll', () => {
       JSON.stringify({
         id: 'pokemon-1',
         name: 'Bulbasaur',
-      })
+      }),
+      130
     );
     const request2 = new Request(
       'get',
@@ -525,7 +538,8 @@ describe('deleteAll', () => {
       JSON.stringify({
         id: 'pokemon-151',
         name: 'Mew',
-      })
+      }),
+      140
     );
 
     await Promise.all([
@@ -584,7 +598,8 @@ describe('deleteByRequestId', () => {
       JSON.stringify({
         id: 'pokemon-1',
         name: 'Bulbasaur',
-      })
+      }),
+      150
     );
     const request2 = new Request(
       'get',
@@ -603,7 +618,8 @@ describe('deleteByRequestId', () => {
       JSON.stringify({
         id: 'pokemon-151',
         name: 'Mew',
-      })
+      }),
+      160
     );
 
     await Promise.all([

--- a/src/infrastructure/repository/RequestRepositoryFile.ts
+++ b/src/infrastructure/repository/RequestRepositoryFile.ts
@@ -173,6 +173,7 @@ export class RequestRepositoryFile implements RequestRepository {
       status: response.status,
       requestHeaders: request.headers,
       responseHeaders: response.headers,
+      responseTime: response.responseTimeInMs,
     });
   }
 
@@ -195,7 +196,8 @@ export class RequestRepositoryFile implements RequestRepository {
     return new Response(
       parseInt(metadata.status, 10),
       metadata.responseHeaders,
-      body
+      body,
+      metadata.responseTime || 0
     );
   }
 

--- a/src/infrastructure/service/NetworkServiceAxios.ts
+++ b/src/infrastructure/service/NetworkServiceAxios.ts
@@ -15,24 +15,35 @@ export class NetworkServiceAxios implements NetworkService {
   }
 
   public async executeRequest(request: Request): Promise<Response> {
-    const axiosResponse = await axios({
-      data: request.body,
-      url: `${this.targetUrl}${request.url}`,
-      headers: request.headers,
-      method: request.method,
-      transformResponse: (data: string) => data,
-    }).catch(error => {
+    const dateBefore = new Date();
+    let dateAfter: Date;
+    let axiosResponse: AxiosResponse<any>;
+
+    try {
+      axiosResponse = await axios({
+        data: request.body,
+        url: `${this.targetUrl}${request.url}`,
+        headers: request.headers,
+        method: request.method,
+        transformResponse: (data: string) => data,
+      });
+    } catch (error) {
       if (!error.response) {
         throw error;
       }
 
-      return error.response as AxiosResponse;
-    });
+      axiosResponse = error.response;
+    } finally {
+      dateAfter = new Date();
+    }
+
+    const responseTime = dateAfter.getTime() - dateBefore.getTime();
 
     return new Response(
       axiosResponse.status,
       axiosResponse.headers,
-      axiosResponse.data
+      axiosResponse.data,
+      responseTime
     );
   }
 }

--- a/src/utils/__mocks__/timer.ts
+++ b/src/utils/__mocks__/timer.ts
@@ -1,0 +1,1 @@
+export const wait = jest.fn();

--- a/src/utils/timers.test.ts
+++ b/src/utils/timers.test.ts
@@ -1,0 +1,28 @@
+import { wait } from './timers';
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('wait', () => {
+  it('should wait by the specified amout of time', async () => {
+    // Given
+    const time = 500;
+    const spy = jest.fn();
+
+    // When
+    wait(time).then(spy);
+
+    expect(spy).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(501);
+    await Promise.resolve();
+
+    // Then
+    expect(spy).toBeCalledTimes(1);
+  });
+});

--- a/src/utils/timers.ts
+++ b/src/utils/timers.ts
@@ -1,0 +1,3 @@
+export function wait(timeInMs: number) {
+  return new Promise(resolve => setTimeout(resolve, timeInMs));
+}

--- a/tests/integration/utils.ts
+++ b/tests/integration/utils.ts
@@ -15,6 +15,7 @@ export function getTestApplication() {
   container.register({
     // Constants
     targetUrl: asValue(targetUrl),
+    useRealResponseTime: asValue(false),
 
     // Use cases
     respondToRequestUseCase: asClass(RespondToRequest),


### PR DESCRIPTION
Fixes #10.

- Add support for simulating the real response time. This response time is stored with the request metadata.
- Response time is now logged in `memento$ info <requestId>`
- This feature is disabled by default (to avoir breaking changes)
- It can be enabled by adding `"useRealResponseTime": true` is `.mementorc`