### PR TITLE
Truncate long requests when generating directory files

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 /* istanbul ignore file */
 
 import Vorpal from 'vorpal';
+import path from 'path';
 import { AwilixContainer } from 'awilix';
 import chalk from 'chalk';
 import table from 'text-table';
@@ -12,6 +13,7 @@ import {
   ListRequest,
   GetRequestDetails,
 } from './domain/usecase';
+import { getRequestDirectory } from './utils/path';
 
 interface CreateCliOptions {
   container: AwilixContainer;
@@ -118,7 +120,27 @@ export function createCli({ container }: CreateCliOptions) {
         requestId
       );
 
-      this.log(chalk`{green Request information}`);
+      const requestDirectoryPath = getRequestDirectory(
+        cacheDirectory,
+        targetUrl,
+        request
+      );
+
+      this.log(chalk`{green Request cache}`);
+      this.log(
+        table([
+          [
+            chalk.yellow('Request directory'),
+            chalk.white(requestDirectoryPath),
+          ],
+          [
+            chalk.yellow('Metadata file'),
+            chalk.white(path.join(requestDirectoryPath, 'metadata.json')),
+          ],
+        ])
+      );
+
+      this.log(chalk`\n\n{green Request information}`);
       this.log(
         table([
           [chalk.yellow('Method'), chalk.white(request.method)],

--- a/src/infrastructure/repository/RequestRepositoryFile.test.ts
+++ b/src/infrastructure/repository/RequestRepositoryFile.test.ts
@@ -209,6 +209,44 @@ describe('persistResponseForRequest', () => {
     });
     expect(bodyContent).toEqual('Hello world');
   });
+
+  it('should persist very long URLs (fixes #30)', async () => {
+    // Given
+    const requestRepository = getRequestRepository();
+    const inputRequest = new Request(
+      'GET',
+      '/really_long_url?with=some&query=parameters[get__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_url]',
+      {},
+      ''
+    );
+    const inputResponse = new Response(200, {}, 'Hello world');
+
+    // When
+    await requestRepository.persistResponseForRequest(
+      inputRequest,
+      inputResponse
+    );
+
+    const metadataContent = await fs.readJSON(
+      `${OUTPUT_DIRECTORY}/get__really_long_url-${inputRequest.id}/metadata.json`
+    );
+    const bodyContent = await fs.readFile(
+      `${OUTPUT_DIRECTORY}/get__really_long_url-${inputRequest.id}/body.txt`,
+      'utf-8'
+    );
+
+    //Then
+    expect(metadataContent).toEqual({
+      method: 'GET',
+      status: 200,
+      url:
+        '/really_long_url?with=some&query=parameters[get__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_url]',
+      requestBody: '',
+      requestHeaders: {},
+      responseHeaders: {},
+    });
+    expect(bodyContent).toEqual('Hello world');
+  });
 });
 
 describe('getResponseByRequestId', () => {

--- a/src/infrastructure/repository/RequestRepositoryFile.ts
+++ b/src/infrastructure/repository/RequestRepositoryFile.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import fs from 'fs-extra';
 
+import { getProjectDirectory, getRequestDirectory } from '../../utils/path';
 import { RequestRepository } from '../../domain/repository';
 import { Request, Response } from '../../domain/entity';
 
@@ -107,11 +108,7 @@ export class RequestRepositoryFile implements RequestRepository {
   }
 
   private getProjectDirectoryPath() {
-    const projectDir = this.targetUrl
-      .replace(/[:\/]/g, '_')
-      .replace(/\./g, '-');
-
-    return path.join(this.cacheDirectory, projectDir);
+    return getProjectDirectory(this.cacheDirectory, this.targetUrl);
   }
 
   private async getSubdirectories() {
@@ -134,13 +131,7 @@ export class RequestRepositoryFile implements RequestRepository {
   }
 
   private getRequestDirectoryPath(request: Request) {
-    const projectDirectoryPath = this.getProjectDirectoryPath();
-    const requestDirectoryPath = `${request.method.toLowerCase()}_${request.url.replace(
-      /\//g,
-      '_'
-    )}-${request.id}`;
-
-    return path.join(projectDirectoryPath, requestDirectoryPath);
+    return getRequestDirectory(this.cacheDirectory, this.targetUrl, request);
   }
 
   private getRequestMetadataFilePath(request: Request) {

--- a/src/utils/path.test.ts
+++ b/src/utils/path.test.ts
@@ -1,0 +1,44 @@
+import { Request } from '../domain/entity';
+import { getProjectDirectory, getRequestDirectory } from './path';
+
+describe('getProjectDirectory', () => {
+  it('should return the project directory', () => {
+    // Given
+    const cacheDirectory = '/tmp/.memento-cache';
+    const targetUrl = 'https://pokeapi.co/api/v2';
+
+    // When
+    const projectDirectory = getProjectDirectory(cacheDirectory, targetUrl);
+
+    //Then
+    expect(projectDirectory).toEqual(
+      '/tmp/.memento-cache/https___pokeapi-co_api_v2'
+    );
+  });
+});
+
+describe('getRequestDirectory', () => {
+  it('should return the request directory', () => {
+    // Given
+    const cacheDirectory = '/tmp/.memento-cache';
+    const targetUrl = 'https://pokeapi.co/api/v2';
+    const request = new Request(
+      'GET',
+      '/really_long_url?with=some&query=parameters[get__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_urlget__really_long_url]',
+      {},
+      ''
+    );
+
+    // When
+    const requestDirectory = getRequestDirectory(
+      cacheDirectory,
+      targetUrl,
+      request
+    );
+
+    //Then
+    expect(requestDirectory).toEqual(
+      '/tmp/.memento-cache/https___pokeapi-co_api_v2/get__really_long_url-25276a6270cf8ba1277f7004a92dece9687f82e1'
+    );
+  });
+});

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,0 +1,24 @@
+import path from 'path';
+
+import { Request } from '../domain/entity';
+
+export function getProjectDirectory(cacheDirectory: string, targetUrl: string) {
+  const projectDir = targetUrl.replace(/[:\/]/g, '_').replace(/\./g, '-');
+
+  return path.join(cacheDirectory, projectDir);
+}
+
+export function getRequestDirectory(
+  cacheDirectory: string,
+  targetUrl: string,
+  request: Request
+) {
+  const projectDirectoryPath = getProjectDirectory(cacheDirectory, targetUrl);
+  const trimmedUrl = request.url.slice(0, 16);
+  const requestDirectoryPath = `${request.method.toLowerCase()}_${trimmedUrl.replace(
+    /\//g,
+    '_'
+  )}-${request.id}`;
+
+  return path.join(projectDirectoryPath, requestDirectoryPath);
+}


### PR DESCRIPTION
Fixes #30

Thanks @sadimusi for reporting this bug. Here is the bug fix, the solution was inspired by your suggestion.

- Most OS have a maximum folder name length about 250 characters.
- In order to apply a backward compatible solution, I decided to keep the request method, url and hash in the folder name, but truncate the url to be 15 chars max (finding the folder without the method and request may be difficult).
- The longest HTTP method (`OPTIONS`) is 7 characters long.
- The separator are 2 + 1 characters long (for __ and -)
- The URL will now be truncated to max 15 characters long in the directory file name
- The hash is a SHA-1 which is always 40 characters long.

So 7 + 3 + 15 + 40 should always be less than 250 :)