### PR TITLE
Feature: option for disabling caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The following options are supported:
 | port                   | The port used to launch Memento                               | 9876                                                   | 3344           |
 | cacheDirectory         | The cache directory used for storing responses                | memento-integration                                    | .memento-cache |
 | useRealResponseTime    | Whether Memento should respond using the actual response time | true                                                   | false          |
-| disableCachingPatterns | An array of patterns usd to ignore caching certain requests   | [{ method: 'post', urlPattern: '/pokemon/*/sprites' }] | []             |
+| disableCachingPatterns | An array of patterns used to ignore caching certain requests  | [{ method: 'post', urlPattern: '/pokemon/*/sprites' }] | []             |
 
 ### Option: disableCachingPatterns
 

--- a/README.md
+++ b/README.md
@@ -53,12 +53,41 @@ _Note: `npx` is a command that comes with `npm` when installing Node and enables
 
 The following options are supported:
 
-| Option              | Description                                                   | Example               | Default value  |
-| ------------------- | ------------------------------------------------------------- | --------------------- | -------------- |
-| targetUrl           | The API base URL                                              | http://localhost:4000 | None           |
-| port                | The port used to launch Memento                               | 9876                  | 3344           |
-| cacheDirectory      | The cache directory used for storing responses                | memento-integration   | .memento-cache |
-| useRealResponseTime | Whether Memento should respond using the actual response time | true                  | false          |
+| Option                 | Description                                                   | Example                                                | Default value  |
+| ---------------------- | ------------------------------------------------------------- | ------------------------------------------------------ | -------------- |
+| targetUrl              | The API base URL                                              | http://localhost:4000                                  | None           |
+| port                   | The port used to launch Memento                               | 9876                                                   | 3344           |
+| cacheDirectory         | The cache directory used for storing responses                | memento-integration                                    | .memento-cache |
+| useRealResponseTime    | Whether Memento should respond using the actual response time | true                                                   | false          |
+| disableCachingPatterns | An array of patterns usd to ignore caching certain requests   | [{ method: 'post', urlPattern: '/pokemon/*/sprites' }] | []             |
+
+### Option: disableCachingPatterns
+
+You may use `disableCachingPatterns` in your configuration to tell Memento to ignore caching responses based on the request method and URL. As an example, if you wish to not cache routes likes `/pokemon/mew/abilities` and `pokemon/ditto/abilities`, you may use the following configuration :
+
+```
+{
+  // ... your configuration
+  "disableCachingPatterns": [{
+    "method": "GET",
+    "urlPattern": "/pokemon/*/abilities"
+  }]
+}
+```
+
+The [minimatch](https://www.npmjs.com/package/minimatch) package is used for comparing glob patterns and the actual url. You may use a tool like [globtester](http://www.globtester.com) to test your configurations.
+
+### Recipe: ignore caching all POST requests
+
+```
+{
+  // ... your configuration
+  "disableCachingPatterns": [{
+    "method": "post",
+    "urlPattern": "**"
+  }]
+}
+```
 
 ## Examples
 

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "fs-extra": "8.1.0",
     "koa": "2.8.1",
     "koa-bodyparser": "4.2.1",
+    "minimatch": "^3.0.4",
     "object-hash": "1.3.1",
     "text-table": "0.2.0",
     "vorpal": "1.12.0"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ import {
   GetRequestDetails,
   SetResponseTime,
 } from './domain/usecase';
+import { DisableCachePattern } from './domain/entity';
 import { getRequestDirectory } from './utils/path';
 
 interface CreateCliOptions {
@@ -23,6 +24,9 @@ interface CreateCliOptions {
 export function createCli({ container }: CreateCliOptions) {
   const targetUrl = container.resolve<string>('targetUrl');
   const cacheDirectory = container.resolve<string>('cacheDirectory');
+  const disableCachingPatterns = container.resolve<DisableCachePattern[]>(
+    'disableCachingPatterns'
+  );
   const clearAllRequestsUseCase = container.resolve<ClearAllRequests>(
     'clearAllRequestsUseCase'
   );
@@ -210,6 +214,16 @@ export function createCli({ container }: CreateCliOptions) {
   console.log(chalk`Using Memento {yellow ${appVersion}}`);
   console.log(chalk`Request will be forwarded to {yellow ${targetUrl}}`);
   console.log(chalk`Cache directory is set to {yellow ${cacheDirectory}}`);
+
+  if (disableCachingPatterns.length) {
+    console.log(chalk`Caching will be disabled for the following patterns:`);
+
+    disableCachingPatterns.forEach(option => {
+      console.log(
+        chalk`\t- {green ${option.method}} {yellow ${option.urlPattern}}`
+      );
+    });
+  }
   console.log(chalk`Type {green help} to get available commands`);
 
   return vorpal;

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -34,6 +34,16 @@ export const configuration = {
   useRealResponseTime: getUseRealResponseTime(
     cosmicConfiguration.config.useRealResponseTime
   ),
+  disableCachingPatterns:
+    cosmicConfiguration.config.disableCachingPatterns || [],
 };
 
 assert(configuration.targetUrl, 'targetUrl option is required');
+
+configuration.disableCachingPatterns.forEach((option: any) => {
+  assert(option.method, 'Invalid disableCachingPatterns: method is required');
+  assert(
+    option.urlPattern,
+    'Invalid disableCachingPatterns: urlPattern is required'
+  );
+});

--- a/src/domain/entity/DisableCachePattern.ts
+++ b/src/domain/entity/DisableCachePattern.ts
@@ -1,0 +1,4 @@
+export interface DisableCachePattern {
+  method: string;
+  urlPattern: string;
+}

--- a/src/domain/entity/index.ts
+++ b/src/domain/entity/index.ts
@@ -2,3 +2,4 @@ export * from './Request';
 export * from './Response';
 export * from './Headers';
 export * from './Method';
+export * from './DisableCachePattern';

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ container.register({
   cacheDirectory: asValue(configuration.cacheDirectory),
   appVersion: asValue(version),
   useRealResponseTime: asValue(configuration.useRealResponseTime),
+  disableCachingPatterns: asValue(configuration.disableCachingPatterns),
 
   // Use cases
   respondToRequestUseCase: asClass(RespondToRequest),

--- a/tests/integration/utils.ts
+++ b/tests/integration/utils.ts
@@ -16,6 +16,7 @@ export function getTestApplication() {
     // Constants
     targetUrl: asValue(targetUrl),
     useRealResponseTime: asValue(false),
+    disableCachingPatterns: asValue([]),
 
     // Use cases
     respondToRequestUseCase: asClass(RespondToRequest),


### PR DESCRIPTION
This pull requests adds a new option to the Memento configuation: `disableCachingPatterns`, which is an array of objects that have a `method` and `pattern` properties.

- The `method` property is a case insensitive HTTP method.
- The `pattern` property is a glob tested against the incoming URL (the minimatch package is used as an implementation).

Fixes #54 .