### PR TITLE
Add config reloading command

### DIFF
--- a/bin/memento.js
+++ b/bin/memento.js
@@ -6,12 +6,15 @@ process.env.NODE_ENV = 'development';
 const { Memento, createCli, runMigrations } = require('../dist');
 
 const memento = Memento();
+const container = memento.container;
 
-memento
-  .run()
-  .then(() => runMigrations(memento.container))
+runMigrations(container)
+  .then(() => memento.run())
   .then(() => {
-    createCli({ container: memento.container }).show();
+    createCli({
+      container: memento.container,
+      reload: memento.reload,
+    }).show();
   });
 
 function stopServer() {

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,11 +10,10 @@ import { scopePerRequest } from 'awilix-koa';
 import { respondToRequest } from './application/http/request';
 
 interface AppOptions {
-  port: number;
   container: AwilixContainer;
 }
 
-export function createApp({ port, container }: AppOptions) {
+export function createApp({ container }: AppOptions) {
   const app = new Koa();
   let server: Server;
 
@@ -27,6 +26,8 @@ export function createApp({ port, container }: AppOptions) {
   return {
     app,
     run() {
+      const port = container.resolve<number>('port');
+
       return new Promise(resolve => {
         server = app.listen(port, resolve);
       });

--- a/src/application/cli/clear/clear.test.ts
+++ b/src/application/cli/clear/clear.test.ts
@@ -1,0 +1,55 @@
+import { CliClear } from '.';
+import { Logger } from '../types';
+import { ClearAllRequests, ClearRequest } from 'domain/usecase';
+
+function getTestDependencies(): {
+  logger: Logger;
+  clearAllRequestsUseCase: ClearAllRequests;
+  clearRequestUseCase: ClearRequest;
+} {
+  return {
+    logger: jest.fn(),
+    // @ts-ignore
+    clearAllRequestsUseCase: {
+      execute: jest.fn().mockResolvedValue(null),
+    },
+    // @ts-ignore
+    clearRequestUseCase: {
+      execute: jest.fn().mockResolvedValue(null),
+    },
+  };
+}
+
+describe('all', () => {
+  it('should clear all requests', async () => {
+    // Given
+    const dependencies = getTestDependencies();
+    const cliClear = new CliClear(dependencies);
+
+    // When
+    await cliClear.all();
+
+    //Then
+    expect(dependencies.clearAllRequestsUseCase.execute).toHaveBeenCalledTimes(
+      1
+    );
+  });
+});
+
+describe('one', () => {
+  it('should clear the request', async () => {
+    // Given
+    const requestId = 'request-id';
+    const dependencies = getTestDependencies();
+    const cliClear = new CliClear(dependencies);
+
+    // When
+    await cliClear.one({ requestId });
+
+    //Then
+    expect(dependencies.clearRequestUseCase.execute).toHaveBeenCalledTimes(1);
+    expect(dependencies.clearRequestUseCase.execute).toHaveBeenCalledWith(
+      'request-id'
+    );
+  });
+});

--- a/src/application/cli/clear/index.ts
+++ b/src/application/cli/clear/index.ts
@@ -1,0 +1,38 @@
+import chalk from 'chalk';
+
+import { ClearAllRequests, ClearRequest } from '../../../domain/usecase';
+import { Logger } from '../types';
+
+interface Dependencies {
+  logger: Logger;
+  clearAllRequestsUseCase: ClearAllRequests;
+  clearRequestUseCase: ClearRequest;
+}
+
+export class CliClear {
+  private logger: Logger;
+  private clearAllRequests: ClearAllRequests;
+  private clearRequest: ClearRequest;
+
+  public constructor({
+    logger,
+    clearAllRequestsUseCase,
+    clearRequestUseCase,
+  }: Dependencies) {
+    this.logger = logger;
+    this.clearAllRequests = clearAllRequestsUseCase;
+    this.clearRequest = clearRequestUseCase;
+  }
+
+  public async all(): Promise<void> {
+    this.logger('Clearing all cached responses...');
+    await this.clearAllRequests.execute();
+    this.logger('Done');
+  }
+
+  public async one({ requestId }: { requestId: string }): Promise<void> {
+    this.logger(chalk`Clearing request {yellow ${requestId}}...`);
+    await this.clearRequest.execute(requestId);
+    this.logger('Done.');
+  }
+}

--- a/src/application/cli/config/index.ts
+++ b/src/application/cli/config/index.ts
@@ -1,0 +1,79 @@
+/* istanbul ignore file */
+
+import chalk from 'chalk';
+import table from 'text-table';
+
+import { DisableCachePattern } from '../../../domain/entity';
+import { Logger } from '../types';
+
+interface Dependencies {
+  appVersion: string;
+  port: number;
+  targetUrl: string;
+  cacheDirectory: string;
+  useRealResponseTime: boolean;
+  disableCachingPatterns: DisableCachePattern[];
+  logger: Logger;
+}
+
+export class CliConfig {
+  private appVersion: string;
+  private cacheDirectory: string;
+  private disableCachingPatterns: DisableCachePattern[];
+  private port: number;
+  private targetUrl: string;
+  private useRealResponseTime: boolean;
+  private logger: Logger;
+
+  public constructor({
+    appVersion,
+    cacheDirectory,
+    disableCachingPatterns,
+    port,
+    targetUrl,
+    useRealResponseTime,
+    logger,
+  }: Dependencies) {
+    this.appVersion = appVersion;
+    this.cacheDirectory = cacheDirectory;
+    this.disableCachingPatterns = disableCachingPatterns;
+    this.port = port;
+    this.targetUrl = targetUrl;
+    this.useRealResponseTime = useRealResponseTime;
+    this.logger = logger;
+  }
+
+  public print(): void {
+    let disableCachingMessage = '';
+
+    if (this.disableCachingPatterns.length) {
+      disableCachingMessage += '\r';
+
+      this.disableCachingPatterns.forEach(option => {
+        disableCachingMessage += chalk`\t\t\t- {green ${option.method}} {yellow ${option.urlPattern}}\n`;
+      });
+
+      disableCachingMessage.trimEnd();
+    } else {
+      disableCachingMessage = chalk.gray('No request');
+    }
+
+    this.logger('Done');
+    this.logger(
+      table([
+        [chalk.white('Memento Version'), chalk.yellow(this.appVersion)],
+        [chalk.white('Port'), chalk.yellow(this.port.toString())],
+        [chalk.white('Target URL'), chalk.yellow(this.targetUrl)],
+        [
+          chalk.white('Use real response time'),
+          chalk.yellow(this.useRealResponseTime.toString()),
+        ],
+        [chalk.white('Cache directory'), chalk.yellow(this.cacheDirectory)],
+        [
+          chalk.white('Disabled cache for'),
+          chalk.yellow(disableCachingMessage),
+        ],
+      ])
+    );
+  }
+}

--- a/src/application/cli/index.ts
+++ b/src/application/cli/index.ts
@@ -1,0 +1,9 @@
+/* istanbul ignore file */
+
+export * from './clear';
+export * from './config';
+export * from './info';
+export * from './ls';
+export * from './refresh';
+export * from './responseTime';
+export * from './injector';

--- a/src/application/cli/info/index.ts
+++ b/src/application/cli/info/index.ts
@@ -1,0 +1,92 @@
+import path from 'path';
+import chalk from 'chalk';
+import table from 'text-table';
+
+import { GetRequestDetails } from '../../../domain/usecase';
+import { getRequestDirectory } from '../../../utils/path';
+import { Logger } from '../types';
+
+interface Dependencies {
+  getRequestDetailsUseCase: GetRequestDetails;
+  cacheDirectory: string;
+  targetUrl: string;
+  logger: Logger;
+}
+
+export class CliInfo {
+  private getRequestDetails: GetRequestDetails;
+  private cacheDirectory: string;
+  private targetUrl: string;
+  private logger: Logger;
+
+  public constructor({
+    getRequestDetailsUseCase,
+    logger,
+    cacheDirectory,
+    targetUrl,
+  }: Dependencies) {
+    this.getRequestDetails = getRequestDetailsUseCase;
+    this.logger = logger;
+    this.cacheDirectory = cacheDirectory;
+    this.targetUrl = targetUrl;
+  }
+
+  public async request({
+    requestId,
+    options,
+  }: {
+    requestId: string;
+    options: { body: boolean };
+  }) {
+    const [request, response] = await this.getRequestDetails.execute(requestId);
+
+    const requestDirectoryPath = getRequestDirectory(
+      this.cacheDirectory,
+      this.targetUrl,
+      request
+    );
+
+    this.logger(chalk`{green Request cache}`);
+    this.logger(
+      table([
+        [chalk.yellow('Request directory'), chalk.white(requestDirectoryPath)],
+        [
+          chalk.yellow('Metadata file'),
+          chalk.white(path.join(requestDirectoryPath, 'metadata.json')),
+        ],
+      ])
+    );
+
+    this.logger(chalk`\n\n{green Request information}`);
+    this.logger(
+      table([
+        [chalk.yellow('Method'), chalk.white(request.method)],
+        [chalk.yellow('URL'), chalk.white(request.url)],
+        ...Object.keys(request.headers).map(headerName => [
+          chalk.yellow(headerName),
+          chalk.white(request.headers[headerName]),
+        ]),
+      ])
+    );
+
+    this.logger(chalk`\n\n{green Response information}`);
+    this.logger(
+      table([
+        [
+          chalk.yellow('Response Time'),
+          chalk.white(response.responseTimeInMs.toString()),
+        ],
+        [chalk.yellow('Status code'), chalk.white(response.status.toString())],
+        ...Object.keys(response.headers).map(headerName => [
+          chalk.yellow(headerName),
+          chalk.white(response.headers[headerName]),
+        ]),
+      ])
+    );
+
+    if (options.body) {
+      this.logger(chalk`\n\n{green Response body}`);
+      this.logger(response.body.toString('utf-8'));
+    }
+  }
+}

--- a/src/application/cli/info/info.test.ts
+++ b/src/application/cli/info/info.test.ts
@@ -1,0 +1,63 @@
+import { GetRequestDetails } from '../../../domain/usecase';
+import { Request, Response } from '../../../domain/entity';
+import { Logger } from '../types';
+import { CliInfo } from '.';
+
+function getTestDependencies(): {
+  getRequestDetailsUseCase: GetRequestDetails;
+  cacheDirectory: string;
+  targetUrl: string;
+  logger: Logger;
+} {
+  return {
+    logger: jest.fn(),
+    cacheDirectory: 'cache-directory',
+    // @ts-ignore
+    getRequestDetailsUseCase: {
+      execute: jest.fn().mockResolvedValue([
+        new Request(
+          'get',
+          '/',
+          {
+            accept: '*/*',
+          },
+          ''
+        ),
+        new Response(
+          200,
+          {
+            'content-type': 'application/json',
+          },
+          Buffer.from(''),
+          0
+        ),
+      ]),
+    },
+    targetUrl: 'target-url',
+  };
+}
+
+describe('request', () => {
+  it('should display the request info', async () => {
+    // Given
+    const requestId = 'request-id';
+    const dependencies = getTestDependencies();
+    const cliInfo = new CliInfo(dependencies);
+
+    // When
+    await cliInfo.request({
+      requestId,
+      options: {
+        body: true,
+      },
+    });
+
+    //Then
+    expect(dependencies.getRequestDetailsUseCase.execute).toHaveBeenCalledTimes(
+      1
+    );
+    expect(dependencies.getRequestDetailsUseCase.execute).toHaveBeenCalledWith(
+      'request-id'
+    );
+  });
+});

--- a/src/application/cli/injector.ts
+++ b/src/application/cli/injector.ts
@@ -1,0 +1,28 @@
+/* istanbul ignore file */
+
+import { AwilixContainer } from 'awilix';
+import Vorpal from 'vorpal';
+
+interface Constructor<T> {
+  new (...args: any): T;
+}
+
+export class CliInjector {
+  public constructor(private container: AwilixContainer) {}
+
+  public action<T extends {}>(
+    ActionController: Constructor<T>,
+    method: keyof T
+  ) {
+    const container = this.container;
+
+    return async function(this: Vorpal.CommandInstance, args: any) {
+      const controller = container.build(ActionController, {
+        injector: () => ({ logger: this.log.bind(this) }),
+      });
+
+      // @ts-ignore
+      await controller[method](args);
+    };
+  }
+}

--- a/src/application/cli/ls/index.ts
+++ b/src/application/cli/ls/index.ts
@@ -1,0 +1,41 @@
+import chalk from 'chalk';
+import table from 'text-table';
+
+import { ListRequest } from '../../../domain/usecase';
+import { Logger } from '../types';
+
+interface Dependencies {
+  listRequestsUseCase: ListRequest;
+  logger: Logger;
+}
+
+export class CliLs {
+  private listRequests: ListRequest;
+  private logger: Logger;
+
+  public constructor({ listRequestsUseCase, logger }: Dependencies) {
+    this.listRequests = listRequestsUseCase;
+    this.logger = logger;
+  }
+
+  public async allRequests() {
+    const requests = await this.listRequests.execute();
+
+    if (requests.length === 0) {
+      this.logger('No request have been cached for now.');
+      return;
+    }
+
+    this.logger('The following requests have been cached:');
+    this.logger(
+      table([
+        [chalk.gray('id'), chalk.gray('method'), chalk.gray('url')],
+        ...requests.map(request => [
+          chalk.yellow(request.id),
+          chalk.green(request.method),
+          chalk.white(request.url),
+        ]),
+      ])
+    );
+  }
+}

--- a/src/application/cli/ls/ls.test.ts
+++ b/src/application/cli/ls/ls.test.ts
@@ -1,0 +1,52 @@
+import { ListRequest } from '../../../domain/usecase';
+import { Request } from '../../../domain/entity';
+import { Logger } from '../types';
+import { CliLs } from '.';
+
+function getTestDependencies(): {
+  listRequestsUseCase: ListRequest;
+  logger: Logger;
+} {
+  return {
+    logger: jest.fn(),
+    // @ts-ignore
+    listRequestsUseCase: {
+      execute: jest.fn().mockResolvedValue([]),
+    },
+  };
+}
+
+describe('allRequests', () => {
+  it('should list all the requests', async () => {
+    // Given
+    const dependencies = getTestDependencies();
+    (dependencies.listRequestsUseCase.execute as jest.Mock).mockResolvedValue([
+      new Request('GET', '/', {}, ''),
+    ]);
+    const cliLs = new CliLs(dependencies);
+
+    // When
+    await cliLs.allRequests();
+
+    //Then
+    expect(dependencies.listRequestsUseCase.execute).toHaveBeenCalledTimes(1);
+    expect(dependencies.logger).not.toHaveBeenCalledWith(
+      'No request have been cached for now.'
+    );
+  });
+
+  it('should display a message if no request have been cached', async () => {
+    // Given
+    const dependencies = getTestDependencies();
+    const cliLs = new CliLs(dependencies);
+
+    // When
+    await cliLs.allRequests();
+
+    //Then
+    expect(dependencies.listRequestsUseCase.execute).toHaveBeenCalledTimes(1);
+    expect(dependencies.logger).toHaveBeenCalledWith(
+      'No request have been cached for now.'
+    );
+  });
+});

--- a/src/application/cli/refresh/index.ts
+++ b/src/application/cli/refresh/index.ts
@@ -1,0 +1,25 @@
+import chalk from 'chalk';
+
+import { RefreshRequest } from '../../../domain/usecase';
+import { Logger } from '../types';
+
+interface Dependencies {
+  refreshRequestUseCase: RefreshRequest;
+  logger: Logger;
+}
+
+export class CliRefresh {
+  private refreshRequest: RefreshRequest;
+  private logger: Logger;
+
+  public constructor({ refreshRequestUseCase, logger }: Dependencies) {
+    this.refreshRequest = refreshRequestUseCase;
+    this.logger = logger;
+  }
+
+  public async request({ requestId }: { requestId: string }) {
+    this.logger(chalk`Refetching data for request {yellow ${requestId}}...`);
+    await this.refreshRequest.execute(requestId);
+    this.logger('Done.');
+  }
+}

--- a/src/application/cli/refresh/refresh.test.ts
+++ b/src/application/cli/refresh/refresh.test.ts
@@ -1,0 +1,34 @@
+import { RefreshRequest } from '../../../domain/usecase';
+import { Logger } from '../types';
+import { CliRefresh } from '.';
+
+function getTestDependencies(): {
+  refreshRequestUseCase: RefreshRequest;
+  logger: Logger;
+} {
+  return {
+    logger: jest.fn(),
+    // @ts-ignore
+    refreshRequestUseCase: {
+      execute: jest.fn().mockResolvedValue(null),
+    },
+  };
+}
+
+describe('request', () => {
+  it('should refresh the request', async () => {
+    // Given
+    const requestId = 'request-id';
+    const dependencies = getTestDependencies();
+    const cliRefresh = new CliRefresh(dependencies);
+
+    // When
+    await cliRefresh.request({ requestId });
+
+    //Then
+    expect(dependencies.refreshRequestUseCase.execute).toHaveBeenCalledTimes(1);
+    expect(dependencies.refreshRequestUseCase.execute).toHaveBeenCalledWith(
+      'request-id'
+    );
+  });
+});

--- a/src/application/cli/responseTime/index.ts
+++ b/src/application/cli/responseTime/index.ts
@@ -1,0 +1,36 @@
+import chalk from 'chalk';
+
+import { SetResponseTime } from '../../../domain/usecase';
+import { Logger } from '../types';
+
+interface Dependencies {
+  setResponseTimeUseCase: SetResponseTime;
+  logger: Logger;
+}
+
+export class CliResponseTime {
+  private setResponseTime: SetResponseTime;
+  private logger: Logger;
+
+  public constructor({ setResponseTimeUseCase, logger }: Dependencies) {
+    this.setResponseTime = setResponseTimeUseCase;
+    this.logger = logger;
+  }
+
+  public async set({
+    requestId,
+    responseTimeInMs,
+  }: {
+    requestId: string;
+    responseTimeInMs: string;
+  }) {
+    this.logger(
+      chalk`Setting response time to {yellow ${responseTimeInMs}ms} for request {yellow ${requestId}}...`
+    );
+    await this.setResponseTime.execute(
+      requestId,
+      parseInt(responseTimeInMs, 10)
+    );
+    this.logger('Done.');
+  }
+}

--- a/src/application/cli/responseTime/responseTime.test.ts
+++ b/src/application/cli/responseTime/responseTime.test.ts
@@ -1,0 +1,38 @@
+import { CliResponseTime } from '.';
+import { Logger } from '../types';
+import { SetResponseTime } from 'domain/usecase';
+
+function getTestDependencies(): {
+  logger: Logger;
+  setResponseTimeUseCase: SetResponseTime;
+} {
+  return {
+    logger: jest.fn(),
+    // @ts-ignore
+    setResponseTimeUseCase: {
+      execute: jest.fn().mockResolvedValue(null),
+    },
+  };
+}
+
+describe('set', () => {
+  it('should set the response time for the provided request id', async () => {
+    // Given
+    const requestId = 'request-id';
+    const responseTimeInMs = '666';
+    const dependencies = getTestDependencies();
+    const cliResponseTime = new CliResponseTime(dependencies);
+
+    // When
+    await cliResponseTime.set({ requestId, responseTimeInMs });
+
+    //Then
+    expect(dependencies.setResponseTimeUseCase.execute).toHaveBeenCalledTimes(
+      1
+    );
+    expect(dependencies.setResponseTimeUseCase.execute).toBeCalledWith(
+      'request-id',
+      666
+    );
+  });
+});

--- a/src/application/cli/types.ts
+++ b/src/application/cli/types.ts
@@ -1,0 +1,1 @@
+export type Logger = (value: string, ...values: string[]) => void;

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -18,32 +18,38 @@ function getUseRealResponseTime(useRealResponseTime: string | undefined) {
   return useRealResponseTime ? Boolean(useRealResponseTime) : false;
 }
 
-const configExplorer = cosmiconfig('memento');
-const cosmicConfiguration = configExplorer.searchSync();
+export function getConfiguration() {
+  const configExplorer = cosmiconfig('memento');
+  const cosmicConfiguration = configExplorer.searchSync();
 
-if (!cosmicConfiguration) {
-  throw new Error(
-    'Memento configuration was not found. Did you create a .mementorc file?'
-  );
+  if (!cosmicConfiguration) {
+    throw new Error(
+      'Memento configuration was not found. Did you create a .mementorc file?'
+    );
+  }
+
+  const configuration = {
+    targetUrl: cosmicConfiguration.config.targetUrl,
+    port: getPortFromString(cosmicConfiguration.config.port),
+    cacheDirectory: getCacheDirectory(
+      cosmicConfiguration.config.cacheDirectory
+    ),
+    useRealResponseTime: getUseRealResponseTime(
+      cosmicConfiguration.config.useRealResponseTime
+    ),
+    disableCachingPatterns:
+      cosmicConfiguration.config.disableCachingPatterns || [],
+  };
+
+  assert(configuration.targetUrl, 'targetUrl option is required');
+
+  configuration.disableCachingPatterns.forEach((option: any) => {
+    assert(option.method, 'Invalid disableCachingPatterns: method is required');
+    assert(
+      option.urlPattern,
+      'Invalid disableCachingPatterns: urlPattern is required'
+    );
+  });
+
+  return configuration;
 }
-
-export const configuration = {
-  targetUrl: cosmicConfiguration.config.targetUrl,
-  port: getPortFromString(cosmicConfiguration.config.port),
-  cacheDirectory: getCacheDirectory(cosmicConfiguration.config.cacheDirectory),
-  useRealResponseTime: getUseRealResponseTime(
-    cosmicConfiguration.config.useRealResponseTime
-  ),
-  disableCachingPatterns:
-    cosmicConfiguration.config.disableCachingPatterns || [],
-};
-
-assert(configuration.targetUrl, 'targetUrl option is required');
-
-configuration.disableCachingPatterns.forEach((option: any) => {
-  assert(option.method, 'Invalid disableCachingPatterns: method is required');
-  assert(
-    option.urlPattern,
-    'Invalid disableCachingPatterns: urlPattern is required'
-  );
-});

--- a/tests/integration/utils.ts
+++ b/tests/integration/utils.ts
@@ -17,6 +17,7 @@ export function getTestApplication() {
     targetUrl: asValue(targetUrl),
     useRealResponseTime: asValue(false),
     disableCachingPatterns: asValue([]),
+    port: asValue(0),
 
     // Use cases
     respondToRequestUseCase: asClass(RespondToRequest),
@@ -29,7 +30,7 @@ export function getTestApplication() {
   });
 
   // Configure supertest
-  const { app } = createApp({ port: 0, container });
+  const { app } = createApp({ container });
   const server = app.listen();
 
   const request = supertest(server);


### PR DESCRIPTION
Fixes #44 

## New command: config

Prints the current configuration

![image](https://user-images.githubusercontent.com/6087868/64077838-64ee9080-ccd4-11e9-911c-dd8f32516a37.png)


## New command: config reload

- Reloads the `.mementorc` file, and reboots the server.
- All options can be updated at runtime. Including the port and the cache directory!

![image](https://user-images.githubusercontent.com/6087868/64077833-586a3800-ccd4-11e9-9670-c22e65e0a4b2.png)
